### PR TITLE
Add Angular Setup Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ You can check out our [Heellife Page](https://heellife.unc.edu/organization/dsca
 # Figma Wireframe
 
 This is the link to the wireframe created in [Figma](https://www.figma.com/design/BbJsypBLO39ENGbjQgxlDu/DSC-Website-Starter?node-id=101-69&t=hYSLoVqjXvnHkug8-1).
+  
+# Setting Up the Angular Workspace
+
+1. Ensure you have [Node.js](https://nodejs.org/en/download/package-manager) installed on your computer.  Check your Node version in terminal using `node -v` and npm version using `npm -v`. 
+2. After cloning the repo, navigate to the app folder with `cd app`. This directory is where the angular project is stored, and likewise all the dependencies we have installed.
+3. Run `npm install` to install the required dependencies.
+
+_This step installs the Angular CLI locally. You will be able to run_ `ng` _commands in the `/DSC-Website/app` directory in the terminal using_ `npm run ng <command>`
+
+4. If you would like to install the Angular CLI globally and be able to use `ng` commands without the `npm run` prefix, run the command `npm install -g @angular/cli`.
+5. Verify Angular is installed by running the command `ng version` or `npm run ng version`.
+
+Your workspace should now be set up to start working with Angular!
+
+To run the development server to preview the website as you make changes to the code, execute the command `ng serve` or `npm start`.


### PR DESCRIPTION
This pull request adds some instructions to get the angular workspace up and running on local machines. 

I personally had a little hiccup specifically getting `ng` commands to work on my end (I realized I didn't have the CLI installed globally), so I thought it would be useful to add a little tutorial in case someone runs into the same issues I did.

Closes #14.